### PR TITLE
Bug fix for erl_img

### DIFF
--- a/src/image_png.erl
+++ b/src/image_png.erl
@@ -52,8 +52,9 @@ scan_info(Fd, IMG, First) ->
     case read_chunk_hdr(Fd) of
         {ok, Length, Type} ->
             Z = zlib:open(),
-            scan_info(Fd, IMG, First, Type, Length, Z),
-            zlib:close(Z);
+            Res = scan_info(Fd, IMG, First, Type, Length, Z),
+            zlib:close(Z),
+			Res;
         Error ->
             Error
     end.


### PR DESCRIPTION
Evan, we're trying to contribute any small changes that Concurix has made to open source projects.  Please let us know if there's a better means than a pull request.

This change fixes an apparent bug where image_png:scan_info would return the result of zlib:close instead of the actual information read from the file.
